### PR TITLE
Add post-set_user hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,15 @@ top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
+
+.PHONY: install-headers uninstall-headers
+
+install: install-headers
+
+install-headers:
+	$(INSTALL_DATA) "set_user.h" $(includedir)
+
+uninstall: uninstall-headers
+
+uninstall-headers:
+	rm "$(includedir)/set_user.h"

--- a/set_user.h
+++ b/set_user.h
@@ -1,0 +1,11 @@
+#ifndef SET_USER_H
+#define SET_USER_H
+
+/* Expose a hook for other extensions to use after reset_user finishes up. */
+typedef void (*post_reset_user_hook_type) (void);
+extern PGDLLIMPORT post_reset_user_hook_type post_reset_user_hook;
+
+/* Expose a hook for other extensions to use after set_user finishes up. */
+typedef void (*post_set_user_hook_type) (const char *username);
+extern PGDLLIMPORT post_set_user_hook_type post_set_user_hook;
+#endif


### PR DESCRIPTION
This commit introduces two hooks which allow another extension to do something
(and return) immediately after `set_user` and `reset_user` are called.

There is a new make target, `make install-headers`, which is responsible for
exposing the hook to other extensions.

To use the post-set_user hooks in an extension:
1) Add '-I$(includedir)' to CPPFLAGS
2) #include set_user.h in whichever file implements the hook
3) Register the 'post_reset_user_hook' and 'post_set_user_hook' with a local
implementation