### PR TITLE
Block RESET SESSION AUTHORIZATION after set_user()

### DIFF
--- a/expected/set_user.out
+++ b/expected/set_user.out
@@ -93,6 +93,9 @@ ERROR:  "SET log_statement" blocked by set_user config
 RESET ROLE; -- should fail
 ERROR:  "RESET role" blocked by set_user
 HINT:  "Use `SELECT reset_user();` to reset role"
+RESET SESSION AUTHORIZATION; -- should fail
+ERROR:  "RESET SESSION AUTHORIZATION" blocked by set_user
+HINT:  "Use `SELECT reset_user();` to reset role"
 SELECT reset_user();
  reset_user 
 ------------

--- a/set_user.c
+++ b/set_user.c
@@ -477,14 +477,6 @@ _PU_HOOK
 							 errhint("\"Use `SELECT reset_user();` to reset role\"")));
 				}
 				else if ((strcmp(((VariableSetStmt *) parsetree)->name,
-					 "user") == 0))
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-							 errmsg("\"RESET user\" blocked by set_user"),
-							 errhint("\"Use `SELECT reset_user();` to reset user\"")));
-				}
-				else if ((strcmp(((VariableSetStmt *) parsetree)->name,
 					 "session_authorization") == 0))
 				{
 					ereport(ERROR,

--- a/set_user.c
+++ b/set_user.c
@@ -484,6 +484,14 @@ _PU_HOOK
 							 errmsg("\"RESET user\" blocked by set_user"),
 							 errhint("\"Use `SELECT reset_user();` to reset user\"")));
 				}
+				else if ((strcmp(((VariableSetStmt *) parsetree)->name,
+					 "session_authorization") == 0))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+							 errmsg("\"RESET SESSION AUTHORIZATION\" blocked by set_user"),
+							 errhint("\"Use `SELECT reset_user();` to reset role\"")));
+				}
 				break;
 			default:
 				break;

--- a/sql/set_user.sql
+++ b/sql/set_user.sql
@@ -55,6 +55,7 @@ BEGIN; SET LOCAL log_statement = 'none'; ABORT;
 
 -- test reset_user
 RESET ROLE; -- should fail
+RESET SESSION AUTHORIZATION; -- should fail
 SELECT reset_user();
 SELECT SESSION_USER, CURRENT_USER;
 


### PR DESCRIPTION
Calls to set_user imply that we are now using set_user to manage
role-related session variables. Previously we blocked `RESET ROLE`, but
it looks like we missed `RESET SESSION AUTHORIZATION`.

Update regression tests to check for all `reset_user()` variants.