### PR TITLE
Add new function set_session_auth()

### DIFF
--- a/set_user--2.0--3.0.sql
+++ b/set_user--2.0--3.0.sql
@@ -1,0 +1,13 @@
+/* set-user-2.0--3.0.sql */
+
+SET LOCAL search_path to @extschema@;
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION set_user UPDATE to '3.0'" to load this file. \quit
+
+CREATE FUNCTION @extschema@.set_session_auth(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_session_auth'
+LANGUAGE C STRICT;
+
+REVOKE EXECUTE ON FUNCTION @extschema@.set_session_auth(text) FROM PUBLIC;

--- a/set_user--3.0.sql
+++ b/set_user--3.0.sql
@@ -1,0 +1,51 @@
+/* set-user--3.0.sql */
+
+SET LOCAL search_path to @extschema@;
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION set_user" to load this file. \quit
+
+CREATE FUNCTION @extschema@.set_user(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.set_user(text, text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C STRICT;
+
+REVOKE EXECUTE ON FUNCTION @extschema@.set_user(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.set_user(text, text) FROM PUBLIC;
+
+CREATE FUNCTION @extschema@.reset_user()
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.reset_user(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C STRICT;
+
+GRANT EXECUTE ON FUNCTION @extschema@.reset_user() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION @extschema@.reset_user(text) TO PUBLIC;
+
+/* New functions in 1.1 (now 1.4) begin here */
+
+CREATE FUNCTION @extschema@.set_user_u(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C STRICT;
+
+REVOKE EXECUTE ON FUNCTION @extschema@.set_user_u(text) FROM PUBLIC;
+
+/* No new sql functions for 1.5 */
+/* No new sql functions for 1.6 */
+/* No new sql functions for 2.0 */
+
+CREATE FUNCTION @extschema@.set_session_auth(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_session_auth'
+LANGUAGE C STRICT;
+REVOKE EXECUTE ON FUNCTION @extschema@.set_session_auth(text) FROM PUBLIC;


### PR DESCRIPTION
Add new function set_session_auth()

set_session_auth() is similar to SET SESSION AUTHORIZATION, except:
1. does not require superuser (GRANTable)
2. does not allow switching to a superuser
3. does not allow reset/switching back
4. Can be configured to throw FATAL/exit for all ERRORs

This new function does not prevent subsequent use of set_user() or
set_user_u(). It effectively switches the session and current user
to a new role.