### PR TITLE
Update authorized uid assertion logic

### DIFF
--- a/compatibility.h
+++ b/compatibility.h
@@ -12,6 +12,10 @@
 #ifndef SET_USER_COMPAT_H
 #define SET_USER_COMPAT_H
 
+#ifndef NO_ASSERT_AUTH_UID_ONCE
+#define NO_ASSERT_AUTH_UID_ONCE !USE_ASSERT_CHECKING
+#endif
+
 /*
  * PostgreSQL version 13+
  *


### PR DESCRIPTION
pgaudit/set_user@b74c1d8 introduced a preprocessor flag to disable
asserts on AuthorizedUserId initialization, but missed the case where
assertions are off altogether and no convencience flag is set.

This commit fixes that issue by simplifying the logic a bit and cleaning
up some of the associated code.