### PR TITLE
Regression and Compilation Fixes

### DIFF
--- a/compatibility.h
+++ b/compatibility.h
@@ -17,12 +17,32 @@
  *
  * Introduces QueryCompletion struct
  */
-#if PG_VERSION_NUM >= 130000
+#if PG_VERSION_NUM >= 140000
 
-static void PU_hook(PlannedStmt *pstmt, const char *queryString,
+static void PU_hook(PlannedStmt *pstmt, const char *queryString, bool readOnlyTree,
 					ProcessUtilityContext context, ParamListInfo params,
 					QueryEnvironment *queryEnv,
 					DestReceiver *dest, QueryCompletion *qc);
+
+#define _PU_HOOK \
+        static void PU_hook(PlannedStmt *pstmt, const char *queryString, bool readOnlyTree, \
+                                                ProcessUtilityContext context, ParamListInfo params, \
+                                                QueryEnvironment *queryEnv, \
+                                                DestReceiver *dest, QueryCompletion *qc)
+
+#define _prev_hook \
+        prev_hook(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc)
+
+#define _standard_ProcessUtility \
+        standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc)
+
+#elif PG_VERSION_NUM >= 130000 && PG_VERSION_NUM < 140000
+
+static void PU_hook(PlannedStmt *pstmt, const char *queryString,
+                                        ProcessUtilityContext context, ParamListInfo params,
+                                        QueryEnvironment *queryEnv,
+                                        DestReceiver *dest, QueryCompletion *qc);
+
 #define _PU_HOOK \
 	static void PU_hook(PlannedStmt *pstmt, const char *queryString, \
 						ProcessUtilityContext context, ParamListInfo params, \

--- a/expected/set_user.out
+++ b/expected/set_user.out
@@ -20,23 +20,6 @@ GRANT newbs TO bob;
 -- joe will be able to escalate without set_user() via su
 GRANT su TO joe;
 GRANT postgres TO su;
--- show deprecated variables
-SHOW set_user.superuser_whitelist;
-NOTICE:  set_user: deprecated GUC name "set_user.superuser_whitelist"
-HINT:  use "set_user.superuser_allowlist" instead
- set_user.superuser_whitelist 
-------------------------------
- *
-(1 row)
-
-SHOW set_user.nosuperuser_target_whitelist;
-NOTICE:  set_user: deprecated GUC name "set_user.nosuperuser_target_whitelist"
-HINT:  use "set_user.nosuperuser_target_allowlist" instead
- set_user.nosuperuser_target_whitelist 
----------------------------------------
- *
-(1 row)
-
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;

--- a/set_user.c
+++ b/set_user.c
@@ -565,7 +565,7 @@ set_session_auth(PG_FUNCTION_ARGS)
 
 #if defined(USE_ASSERT_CHECKING) && !defined(NO_ASSERT_AUTH_UID_ONCE)
 	elog(ERROR, "Assert build disables set_session_auth()");
-#else
+#elif defined(NO_ASSERT_AUTH_UID_ONCE)
 	/* Look up the username */
 	roleTup = SearchSysCache1(AUTHNAME, PointerGetDatum(newuser));
 	if (!HeapTupleIsValid(roleTup))

--- a/sql/set_user.sql
+++ b/sql/set_user.sql
@@ -25,10 +25,6 @@ GRANT newbs TO bob;
 GRANT su TO joe;
 GRANT postgres TO su;
 
--- show deprecated variables
-SHOW set_user.superuser_whitelist;
-SHOW set_user.nosuperuser_target_whitelist;
-
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;


### PR DESCRIPTION
The PR contains 3 commits:

1. Updated SQL and out files to remove deprecated GUC warning.
2. Fixed compilation issue when the server is not built with NO_ASSERT_AUTH_UID_ONCE option.
3. Fixed compilation issue for PG 14.