### PR TITLE
Fix invalid include on PG_VERSION < 10

### DIFF
--- a/deprecated_gucs.h
+++ b/deprecated_gucs.h
@@ -17,7 +17,6 @@
  */
 #include "miscadmin.h"
 #include "utils/guc.h"
-#include "utils/varlena.h"
 
 static bool
 check_set_user_list(char **newval, void **extra, GucSource source,


### PR DESCRIPTION
deprecated_gucs.h explicitly includes a header that is not necessary.
Drop it so we can support postgres version 9.6 and lower.