### PR TITLE
Get rid of deprecated GUCs output in test

### DIFF
--- a/expected/set_user.out
+++ b/expected/set_user.out
@@ -20,23 +20,6 @@ GRANT newbs TO bob;
 -- joe will be able to escalate without set_user() via su
 GRANT su TO joe;
 GRANT postgres TO su;
--- show deprecated variables
-SHOW set_user.superuser_whitelist;
-NOTICE:  set_user: deprecated GUC name "set_user.superuser_whitelist"
-HINT:  use "set_user.superuser_allowlist" instead
- set_user.superuser_whitelist 
-------------------------------
- *
-(1 row)
-
-SHOW set_user.nosuperuser_target_whitelist;
-NOTICE:  set_user: deprecated GUC name "set_user.nosuperuser_target_whitelist"
-HINT:  use "set_user.nosuperuser_target_allowlist" instead
- set_user.nosuperuser_target_whitelist 
----------------------------------------
- *
-(1 row)
-
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;

--- a/sql/set_user.sql
+++ b/sql/set_user.sql
@@ -25,10 +25,6 @@ GRANT newbs TO bob;
 GRANT su TO joe;
 GRANT postgres TO su;
 
--- show deprecated variables
-SHOW set_user.superuser_whitelist;
-SHOW set_user.nosuperuser_target_whitelist;
-
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;


### PR DESCRIPTION
Deprecation GUC notices should only be displayed whenever non-default
values exist in postgresql.*.conf. Since we can't be certain of these
values during a regression test invocation, just skip checking
altogether.