### PR TITLE
Introduce object_access hook to set_user

### DIFF
--- a/compatibility.h
+++ b/compatibility.h
@@ -34,6 +34,9 @@
 #define _standard_ProcessUtility \
 	standard_ProcessUtility(pstmt, queryString, ReadOnlyTree, context, params, queryEnv, dest, qc)
 
+#define getObjectIdentity(address) \
+	getObjectIdentity(address,false)
+
 #endif /* 14+ */
 
 /*

--- a/expected/set_user.out
+++ b/expected/set_user.out
@@ -75,6 +75,17 @@ RESET log_statement;
 ERROR:  "SET log_statement" blocked by set_user config
 BEGIN; SET LOCAL log_statement = 'none'; ABORT;
 ERROR:  "SET log_statement" blocked by set_user config
+-- set_config() should fail
+SELECT set_config('wal_level', 'minimal', false);
+ERROR:  "pg_catalog.set_config(pg_catalog.text,pg_catalog.text,boolean)" blocked by set_user
+HINT:  Use "SET" syntax instead.
+CREATE OR REPLACE FUNCTION backdoor(text, text, boolean) RETURNS BOOL AS 'set_config_by_name' LANGUAGE INTERNAL;
+SELECT backdoor('log_statement', 'none', true);
+ERROR:  "public.backdoor(pg_catalog.text,pg_catalog.text,boolean)" blocked by set_user
+HINT:  Use "SET" syntax instead.
+UPDATE pg_settings SET setting = 'none' WHERE name = 'log_statement';
+ERROR:  "pg_catalog.set_config(pg_catalog.text,pg_catalog.text,boolean)" blocked by set_user
+HINT:  Use "SET" syntax instead.
 -- test reset_user
 RESET ROLE; -- should fail
 ERROR:  "SET/RESET ROLE" blocked by set_user

--- a/sql/set_user.sql
+++ b/sql/set_user.sql
@@ -52,6 +52,12 @@ SET log_statement = DEFAULT;
 RESET log_statement;
 BEGIN; SET LOCAL log_statement = 'none'; ABORT;
 
+-- set_config() should fail
+SELECT set_config('wal_level', 'minimal', false);
+CREATE OR REPLACE FUNCTION backdoor(text, text, boolean) RETURNS BOOL AS 'set_config_by_name' LANGUAGE INTERNAL;
+SELECT backdoor('log_statement', 'none', true);
+UPDATE pg_settings SET setting = 'none' WHERE name = 'log_statement';
+
 -- test reset_user
 RESET ROLE; -- should fail
 RESET SESSION AUTHORIZATION; -- should fail


### PR DESCRIPTION
PostgreSQL allows a user to bypass normal `SET ...` code paths by
calling the builtin `set_config()` function.  The result is modification
of GUCs and ROLEs without hitting the ProcessUtility hook.

Since `set_user()` heavily leverages the ProcessUtility hook to block
modification of specific GUCs and ROLEs, we need to mitigate the
`set_config()` bypass.

In order to appropriately block this bypass, we need to add an object
access hook and prevent users of `set_user` from executing the
`set_config()` function altogether.

Since this is a fairly heavy operation, which requires scanning the
heap, maintain a cached List of function Oids whose source is
`set_config_by_name()`.  Make sure to update the cache on function
CREATE/UPDATE.