### PR TITLE
Free pending_state during reset_user() NOOP

### DIFF
--- a/expected/set_user.out
+++ b/expected/set_user.out
@@ -20,6 +20,13 @@ GRANT newbs TO bob;
 -- joe will be able to escalate without set_user() via su
 GRANT su TO joe;
 GRANT postgres TO su;
+-- test reset_user with no initial set
+SELECT reset_user();
+ reset_user 
+------------
+ OK
+(1 row)
+
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;

--- a/expected/set_user_1.out
+++ b/expected/set_user_1.out
@@ -20,6 +20,13 @@ GRANT newbs TO bob;
 -- joe will be able to escalate without set_user() via su
 GRANT su TO joe;
 GRANT postgres TO su;
+-- test reset_user with no initial set
+SELECT reset_user();
+ reset_user 
+------------
+ OK
+(1 row)
+
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;

--- a/expected/set_user_2.out
+++ b/expected/set_user_2.out
@@ -20,6 +20,13 @@ GRANT newbs TO bob;
 -- joe will be able to escalate without set_user() via su
 GRANT su TO joe;
 GRANT postgres TO su;
+-- test reset_user with no initial set
+SELECT reset_user();
+ reset_user 
+------------
+ OK
+(1 row)
+
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;

--- a/sql/set_user.sql
+++ b/sql/set_user.sql
@@ -25,6 +25,9 @@ GRANT newbs TO bob;
 GRANT su TO joe;
 GRANT postgres TO su;
 
+-- test reset_user with no initial set
+SELECT reset_user();
+
 -- test set_user
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;


### PR DESCRIPTION
Commit 274f426f0732 ("Add set_user transaction callbacks") introduced
transaction callbacks for handling of set_user state.

Pending transaction state is set at the beginning of any set/reset user call. When
calling `reset_user()` prior to `set_user[_u]()`, the pending state was
allocated and not free'ed.

The resulting segfault stemmed from the fact that the transaction handler would
then fire and see that pending state was non-NULL and thus assume that a
`set_user()` transaction was under way. At this point it should be safe to use
the transaction state variables, so a NULL dereference was made.

This commit fixes issue #58 by:

- free()'ing the pending state on singleton `reset_user()`
- adding more thorough checks to the transaction handler to prevent this from occuring in the
future
- adding a regression test to test this case