### PR TITLE
Fix tests with PG 15

### DIFF
--- a/expected/set_user.out
+++ b/expected/set_user.out
@@ -168,6 +168,11 @@ ALTER SYSTEM SET wal_level = minimal;
 COPY (select 42) TO PROGRAM 'cat';
 SET log_statement = DEFAULT;
 -- test transaction handling
+CREATE FUNCTION bail() RETURNS bool AS $$
+BEGIN
+	RAISE EXCEPTION 'bailing out !';
+END;
+$$ LANGUAGE plpgsql;
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;
  session_user | current_user 
@@ -175,11 +180,6 @@ SELECT SESSION_USER, CURRENT_USER;
  dba          | dba
 (1 row)
 
-CREATE FUNCTION bail() RETURNS bool AS $$
-BEGIN
-	RAISE EXCEPTION 'bailing out !';
-END;
-$$ LANGUAGE plpgsql;
 -- bail during set_user_u
 SELECT set_user_u('postgres'), bail();
 ERROR:  bailing out !

--- a/expected/set_user_1.out
+++ b/expected/set_user_1.out
@@ -168,6 +168,11 @@ ALTER SYSTEM SET wal_level = minimal;
 COPY (select 42) TO PROGRAM 'cat';
 SET log_statement = DEFAULT;
 -- test transaction handling
+CREATE FUNCTION bail() RETURNS bool AS $$
+BEGIN
+	RAISE EXCEPTION 'bailing out !';
+END;
+$$ LANGUAGE plpgsql;
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;
  session_user | current_user 
@@ -175,11 +180,6 @@ SELECT SESSION_USER, CURRENT_USER;
  dba          | dba
 (1 row)
 
-CREATE FUNCTION bail() RETURNS bool AS $$
-BEGIN
-	RAISE EXCEPTION 'bailing out !';
-END;
-$$ LANGUAGE plpgsql;
 -- bail during set_user_u
 SELECT set_user_u('postgres'), bail();
 ERROR:  bailing out !

--- a/expected/set_user_2.out
+++ b/expected/set_user_2.out
@@ -168,6 +168,11 @@ ALTER SYSTEM SET wal_level = minimal;
 COPY (select 42) TO PROGRAM 'cat';
 SET log_statement = DEFAULT;
 -- test transaction handling
+CREATE FUNCTION bail() RETURNS bool AS $$
+BEGIN
+	RAISE EXCEPTION 'bailing out !';
+END;
+$$ LANGUAGE plpgsql;
 SET SESSION AUTHORIZATION dba;
 SELECT SESSION_USER, CURRENT_USER;
  session_user | current_user 
@@ -175,11 +180,6 @@ SELECT SESSION_USER, CURRENT_USER;
  dba          | dba
 (1 row)
 
-CREATE FUNCTION bail() RETURNS bool AS $$
-BEGIN
-	RAISE EXCEPTION 'bailing out !';
-END;
-$$ LANGUAGE plpgsql;
 -- bail during set_user_u
 SELECT set_user_u('postgres'), bail();
 ERROR:  bailing out !

--- a/sql/set_user.sql
+++ b/sql/set_user.sql
@@ -88,13 +88,13 @@ COPY (select 42) TO PROGRAM 'cat';
 SET log_statement = DEFAULT;
 
 -- test transaction handling
-SET SESSION AUTHORIZATION dba;
-SELECT SESSION_USER, CURRENT_USER;
 CREATE FUNCTION bail() RETURNS bool AS $$
 BEGIN
 	RAISE EXCEPTION 'bailing out !';
 END;
 $$ LANGUAGE plpgsql;
+SET SESSION AUTHORIZATION dba;
+SELECT SESSION_USER, CURRENT_USER;
 
 -- bail during set_user_u
 SELECT set_user_u('postgres'), bail();


### PR DESCRIPTION
PG 15 removes public create privilege on the public schema, create function bail() before changing user.

Noted when creating Debian packages for set_user.