### PR TITLE
Bump pg15 regression test from beta

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -18,10 +18,7 @@ jobs:
       DEVPKG: ${{ matrix.devpkg }}
     strategy:
       matrix:
-        pgver: [9.4, 9.5, 9.6, 10, 11, 12, 13, 14]
-        include:
-          - pgver: "15beta3"
-            devpkg: 15
+        pgver: [9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15]
 
     steps:
       - name: Checkout set_user repo


### PR DESCRIPTION
Should take care of pg15 CI regression testing now that it's been officially released.