### PR TITLE
Build with USE_PGXS by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,9 @@ REGRESS = set_user
 
 LDFLAGS_SL += $(filter -lm, $(LIBS))
 
-ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-else
-subdir = contrib/set_user
-top_builddir = ../..
-include $(top_builddir)/src/Makefile.global
-include $(top_srcdir)/contrib/contrib-global.mk
-endif
 
 .PHONY: install-headers uninstall-headers
 


### PR DESCRIPTION
This isn't being built within contrib, so no point in having the contrib defaults.