### PR TITLE
Add support for upgrading from 3.0 or 4.0.0RC1 to 4.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULES = set_user
 
 EXTENSION = set_user
-DATA = set_user--3.0.sql set_user--2.0--3.0.sql set_user--1.6--2.0.sql set_user--1.5--1.6.sql set_user--1.4--1.5.sql set_user--1.1--1.4.sql set_user--1.0--1.1.sql set_user--4.0.0rc1.sql set_user--3.0--4.0.0rc1.sql
+DATA = set_user--3.0.sql set_user--2.0--3.0.sql set_user--1.6--2.0.sql set_user--1.5--1.6.sql set_user--1.4--1.5.sql set_user--1.1--1.4.sql set_user--1.0--1.1.sql set_user--4.0.0rc1--4.0.0.sql set_user--3.0--4.0.0.sql
 PGFILEDESC = "set_user - similar to SET ROLE but with added logging"
 
 REGRESS = set_user

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULES = set_user
 
 EXTENSION = set_user
-DATA = set_user--3.0.sql set_user--2.0--3.0.sql set_user--1.6--2.0.sql set_user--1.5--1.6.sql set_user--1.4--1.5.sql set_user--1.1--1.4.sql set_user--1.0--1.1.sql set_user--4.0.0rc1--4.0.0.sql set_user--3.0--4.0.0.sql
+DATA = set_user--3.0.sql set_user--2.0--3.0.sql set_user--1.6--2.0.sql set_user--1.5--1.6.sql set_user--1.4--1.5.sql set_user--1.1--1.4.sql set_user--1.0--1.1.sql set_user--4.0.0rc1--4.0.0.sql set_user--4.0.0.sql set_user--3.0--4.0.0.sql
 PGFILEDESC = "set_user - similar to SET ROLE but with added logging"
 
 REGRESS = set_user

--- a/set_user--3.0--4.0.0.sql
+++ b/set_user--3.0--4.0.0.sql
@@ -1,0 +1,6 @@
+/* set-user-3.0--4.0.0.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION set_user UPDATE" to load this file. \quit
+
+-- just bumping our version to 4.0.0. no new SQL features here, so nothing to do.

--- a/set_user--4.0.0.sql
+++ b/set_user--4.0.0.sql
@@ -1,0 +1,55 @@
+/* set-user--4.0.0.sql */
+
+SET LOCAL search_path to @extschema@;
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION set_user" to load this file. \quit
+
+CREATE FUNCTION @extschema@.set_user(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.set_user(text, text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C STRICT;
+
+REVOKE EXECUTE ON FUNCTION @extschema@.set_user(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION @extschema@.set_user(text, text) FROM PUBLIC;
+
+CREATE FUNCTION @extschema@.reset_user()
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.reset_user(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C STRICT;
+
+GRANT EXECUTE ON FUNCTION @extschema@.reset_user() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION @extschema@.reset_user(text) TO PUBLIC;
+
+/* New functions in 1.1 (now 1.4) begin here */
+
+CREATE FUNCTION @extschema@.set_user_u(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_user'
+LANGUAGE C STRICT;
+
+REVOKE EXECUTE ON FUNCTION @extschema@.set_user_u(text) FROM PUBLIC;
+
+/* No new sql functions for 1.5 */
+/* No new sql functions for 1.6 */
+/* No new sql functions for 2.0 */
+
+/* New functions in 3.0 begin here */
+
+CREATE FUNCTION @extschema@.set_session_auth(text)
+RETURNS text
+AS 'MODULE_PATHNAME', 'set_session_auth'
+LANGUAGE C STRICT;
+REVOKE EXECUTE ON FUNCTION @extschema@.set_session_auth(text) FROM PUBLIC;
+
+/* No new sql functions for 4.0.0 */

--- a/set_user--4.0.0rc1--4.0.0.sql
+++ b/set_user--4.0.0rc1--4.0.0.sql
@@ -1,0 +1,6 @@
+/* set-user--4.0.0rc1--4.0.0.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION set_user UPDATE" to load this file. \quit
+
+-- Allow users that may have installed 4.0.0RC1 to upgrade to 4.0.0 stable

--- a/set_user.control
+++ b/set_user.control
@@ -1,5 +1,5 @@
 # set_user extension
 comment = 'similar to SET ROLE but with added logging'
-default_version = '4.0.0rc1'
+default_version = '4.0.0'
 module_pathname = '$libdir/set_user'
 relocatable = false


### PR DESCRIPTION
Allow upgrading from either 4.0.0rc1 or 3.0 to 4.0.0 final. Upgrade path should prefer going directly from 3.0 to 4.0.0 and skipping RC.
```
keith=# select * from pg_extension_update_paths('set_user') where source = '3.0' and target LIKE '4.0.0%';
 source |  target  |     path      
--------+----------+---------------
 3.0    | 4.0.0    | 3.0--4.0.0
 3.0    | 4.0.0rc1 | 3.0--4.0.0rc1
(2 rows)

keith=# select * from pg_extension_update_paths('set_user') where source = '3.0' and target = '4.0.0';
 source | target |    path    
--------+--------+------------
 3.0    | 4.0.0  | 3.0--4.0.0
(1 row)

keith=# select * from pg_extension_update_paths('set_user') where source = '4.0.0rc1' and target = '4.0.0';
  source  | target |      path       
----------+--------+-----------------
 4.0.0rc1 | 4.0.0  | 4.0.0rc1--4.0.0
```