### PR TITLE
Fix 9.6 ci

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -4,6 +4,8 @@ ARG PGVER
 FROM postgres:${PGVER}
 ARG PGVER
 ARG DEVPKG
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /src/set_user
 WORKDIR /src/set_user
 RUN apt-get update && \

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -17,6 +17,7 @@ jobs:
       SCRIPT_DIR: ${{ github.workspace }}/.github/resources/scripts
       DEVPKG: ${{ matrix.devpkg }}
     strategy:
+      fail-fast: false
       matrix:
         pgver: [9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15]
 


### PR DESCRIPTION
Let the docker build process continue without user intervention. Don't block all tests on one failure.