### PR TITLE
docs: add a note that whitelist is fully dropped and defaults may be used for allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,8 @@ test=> select session_user, current_user, user, current_role;
 
 ## NOTES
 
+### Version 4.0.0
+- Support for the previously deprecated `whitelist` GUCs is removed. Please update your config to the new `allowlist` equivalent otherwise the default values for the `allowlist` GUCs will be in effect potentially allowing undesired privilege escalation.
 ### Version 2.0.1
 
 - NOTICE fixed to only display on first reference to non-default deprecated

--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ test=> select session_user, current_user, user, current_role;
 ## NOTES
 
 ### Version 4.0.0
+
 - Support for the previously deprecated `whitelist` GUCs is removed. Please update your config to the new `allowlist` equivalent otherwise the default values for the `allowlist` GUCs will be in effect potentially allowing undesired privilege escalation.
 
 ### Version 2.0.1

--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ test=> select session_user, current_user, user, current_role;
 
 ### Version 4.0.0
 - Support for the previously deprecated `whitelist` GUCs is removed. Please update your config to the new `allowlist` equivalent otherwise the default values for the `allowlist` GUCs will be in effect potentially allowing undesired privilege escalation.
+
 ### Version 2.0.1
 
 - NOTICE fixed to only display on first reference to non-default deprecated

--- a/README.md
+++ b/README.md
@@ -806,11 +806,6 @@ test=> select session_user, current_user, user, current_role;
 
 - The extension is now non-relocatable and all functions are schema-qualified.
 
-### Version 4.0.0-rc1
-
-- Use of GUCs with `whitelist` have been removed from the codebase. Please use
-  the newer `allowlist` GUCs.
-
 ##  Licensing
 
 Please see the [LICENSE](./LICENSE) file.


### PR DESCRIPTION
With the 4.0 release, the old whitelist GUCs are fully dropped but if a user hasn't migrated to the new allowlist GUCs then you could end up with more people being able to become superuser than you intended so add a note calling this out.