### PR TITLE
Restore Windows compatibility in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,15 @@ REGRESS = set_user
 
 LDFLAGS_SL += $(filter -lm, $(LIBS))
 
-ifdef USE_PGXS
-PG_CONFIG = pg_config
-PGXS := $(shell $(PG_CONFIG) --pgxs)
-include $(PGXS)
-else
+ifdef WINDOWS_DISUSE_PGXS
 subdir = contrib/set_user
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
+else
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
 endif
 
 .PHONY: install-headers uninstall-headers

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ REGRESS = set_user
 
 LDFLAGS_SL += $(filter -lm, $(LIBS))
 
-ifdef WINDOWS_DISUSE_PGXS
+ifdef NO_PGXS
 subdir = contrib/set_user
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,16 @@ REGRESS = set_user
 
 LDFLAGS_SL += $(filter -lm, $(LIBS))
 
+ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/set_user
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 .PHONY: install-headers uninstall-headers
 


### PR DESCRIPTION
Removal of the if conditional in Makefile between 3.0.0 and 4.0.0 breaks Windows Build Compatibility

On Windows, PostgreSQL Build is performed without USE_PGXS.

If PGXS is already defined before the make, Windows fails to generate win32ver.rc which is needed by win32ver.o, and causes the make target to fail.