### PR TITLE
PostgreSQL 17 support

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgver: [12, 13, 14, 15]
+        pgver: [12, 13, 14, 15, 16, 17beta2]
 
     steps:
       - name: Checkout set_user repo
@@ -28,7 +28,9 @@ jobs:
       - name: Set DEVPKG to pgver if unset
         if: ${{ env.DEVPKG == '' }}
         run: |
-          echo "DEVPKG=${{ matrix.pgver }}" >> $GITHUB_ENV;  
+          # Cut off label and leave only major version number (17beta2 -> 17)
+          DEVPKG=$(echo ${{ matrix.pgver }} | sed 's/^\([0-9]\{2\}\).*/\1/')
+          echo "DEVPKG=$DEVPKG" >> $GITHUB_ENV;
 
       - name: Build set_user
         run: |

--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -17,6 +17,20 @@
 #endif
 
 /*
+ * PostgreSQL version 17+
+ *
+ * - Sets bypass_login_check parameter to false in InitializeSessionUserId funcion
+ */
+#if PG_VERSION_NUM >= 170000
+
+#ifndef INITSESSIONUSER
+#define INITSESSIONUSER
+#define _InitializeSessionUserId(name,ouserid) InitializeSessionUserId(name,ouserid,false)
+#endif
+
+#endif /* 17+ */
+
+/*
  * PostgreSQL version 14+
  *
  * Introduces ReadOnlyTree boolean
@@ -135,8 +149,10 @@ _heap_tuple_get_oid(HeapTuple tuple, Oid catalogID)
 #if PG_VERSION_NUM >= 90500
 #define GETUSERNAMEFROMID(ouserid) GetUserNameFromId(ouserid, false)
 
+#ifndef INITSESSIONUSER
 #define INITSESSIONUSER
 #define _InitializeSessionUserId(name,ouserid) InitializeSessionUserId(name,ouserid)
+#endif
 
 #endif /* 9.5+ */
 


### PR DESCRIPTION
This PR adds PG17 support.

The only change that breaks compatibility for this extension is `InitializeSessionUserId` function signature change:
https://github.com/postgres/postgres/commit/e7689190b3d58404abbafe2d3312c3268a51cca3

Also I've added PG 16 and 17beta2 to regression test matrix in CI.