### PR TITLE
Remove support for PostgreSQL < 12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ variety of nefarious or otherwise undesireable actions. However, these actions
 will be logged providing an audit trail, which could also be used to trigger
 alerts.
 
-This extension supports PostgreSQL versions 9.4 and higher.
+This extension supports PostgreSQL versions 12 and higher. Prior versions of
+PostgreSQL are supported by prior versions of set_user.
 
 ##  Post-Execution Hooks
 
@@ -744,19 +745,19 @@ psql (15.4)
 Type "help" for help.
 
 test=> select session_user, current_user, user, current_role;
- session_user | current_user |   user   | current_role 
+ session_user | current_user |   user   | current_role
 --------------+--------------+----------+--------------
  dbclient     | dbclient     | dbclient | dbclient
 (1 row)
 
 test=> select set_session_auth('jeff');
- set_session_auth 
+ set_session_auth
 ------------------
  OK
 (1 row)
 
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role 
+ session_user | current_user | user | current_role
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)
@@ -765,7 +766,7 @@ test=> -- the role switch is irrevocable
 test=> reset role;
 RESET
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role 
+ session_user | current_user | user | current_role
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)
@@ -773,7 +774,7 @@ test=> select session_user, current_user, user, current_role;
 test=> reset session authorization;
 RESET
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role 
+ session_user | current_user | user | current_role
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)
@@ -781,7 +782,7 @@ test=> select session_user, current_user, user, current_role;
 test=> set role none;
 SET
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role 
+ session_user | current_user | user | current_role
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)

--- a/README.md
+++ b/README.md
@@ -745,19 +745,19 @@ psql (15.4)
 Type "help" for help.
 
 test=> select session_user, current_user, user, current_role;
- session_user | current_user |   user   | current_role
+ session_user | current_user |   user   | current_role 
 --------------+--------------+----------+--------------
  dbclient     | dbclient     | dbclient | dbclient
 (1 row)
 
 test=> select set_session_auth('jeff');
- set_session_auth
+ set_session_auth 
 ------------------
  OK
 (1 row)
 
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role
+ session_user | current_user | user | current_role 
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)
@@ -766,7 +766,7 @@ test=> -- the role switch is irrevocable
 test=> reset role;
 RESET
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role
+ session_user | current_user | user | current_role 
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)
@@ -774,7 +774,7 @@ test=> select session_user, current_user, user, current_role;
 test=> reset session authorization;
 RESET
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role
+ session_user | current_user | user | current_role 
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)
@@ -782,7 +782,7 @@ test=> select session_user, current_user, user, current_role;
 test=> set role none;
 SET
 test=> select session_user, current_user, user, current_role;
- session_user | current_user | user | current_role
+ session_user | current_user | user | current_role 
 --------------+--------------+------+--------------
  jeff         | jeff         | jeff | jeff
 (1 row)

--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -83,6 +83,25 @@
  * - Removes OID column
  */
 #if PG_VERSION_NUM >= 120000
+
+#ifndef _PU_HOOK
+#define _PU_HOOK \
+	static void PU_hook(PlannedStmt *pstmt, const char *queryString, \
+						ProcessUtilityContext context, ParamListInfo params, \
+						QueryEnvironment *queryEnv, \
+						DestReceiver *dest, char *completionTag)
+
+#define _prev_hook \
+	prev_hook(pstmt, queryString, context, params, queryEnv, dest, completionTag)
+
+#define _standard_ProcessUtility \
+	standard_ProcessUtility(pstmt, queryString, context, params, queryEnv, dest, completionTag)
+
+#endif
+
+#include "utils/varlena.h"
+#define parsetree ((Node *) pstmt->utilityStmt)
+
 #define HEAP_TUPLE_GET_OID
 
 /*
@@ -112,97 +131,6 @@ _heap_tuple_get_oid(HeapTuple tuple, Oid catalogID)
 
 #include "access/table.h"
 #define OBJECTADDRESS
-#endif /* 12+ */
-
-/*
- * PostgreSQL version 10+
- *
- * - Introduces PlannedStmt struct
- * - Introduces varlena.h
- */
-#if PG_VERSION_NUM >= 100000
-#ifndef _PU_HOOK
-#define _PU_HOOK \
-	static void PU_hook(PlannedStmt *pstmt, const char *queryString, \
-						ProcessUtilityContext context, ParamListInfo params, \
-						QueryEnvironment *queryEnv, \
-						DestReceiver *dest, char *completionTag)
-
-#define _prev_hook \
-	prev_hook(pstmt, queryString, context, params, queryEnv, dest, completionTag)
-
-#define _standard_ProcessUtility \
-	standard_ProcessUtility(pstmt, queryString, context, params, queryEnv, dest, completionTag)
-
-#endif
-
-#include "utils/varlena.h"
-#define parsetree ((Node *) pstmt->utilityStmt)
-
-#endif /* 10+ */
-
-/*
- * PostgreSQL version 9.5+
- *
- * - Introduces two-argument GetUserNameFromId
- */
-#if PG_VERSION_NUM >= 90500
-#define GETUSERNAMEFROMID(ouserid) GetUserNameFromId(ouserid, false)
-
-#ifndef INITSESSIONUSER
-#define INITSESSIONUSER
-#define _InitializeSessionUserId(name,ouserid) InitializeSessionUserId(name,ouserid)
-#endif
-
-#endif /* 9.5+ */
-
-/*
- * PostgreSQL version 9.4+
- *
- * Lowest supported version.
- */
-#if PG_VERSION_NUM >= 90400
-#ifndef _PU_HOOK
-#define _PU_HOOK \
-	static void PU_hook(Node *parsetree, const char *queryString, \
-						ProcessUtilityContext context, ParamListInfo params, \
-						DestReceiver *dest, char *completionTag)
-
-#define _prev_hook \
-	prev_hook(parsetree, queryString, context, params, dest, completionTag)
-
-#define _standard_ProcessUtility \
-	standard_ProcessUtility(parsetree, queryString, context, params, dest, completionTag)
-#endif
-
-#ifndef GETUSERNAMEFROMID
-#define GETUSERNAMEFROMID(ouserid) GetUserNameFromId(ouserid)
-#endif
-
-# ifndef HEAP_TUPLE_GET_OID
-static inline Oid
-_heap_tuple_get_oid(HeapTuple tup, Oid catalogId)
-{
-	return HeapTupleGetOid(tup);
-}
-# endif
-
-#ifndef TABLEOPEN
-#define table_open(r, l)	heap_open(r, l)
-#define table_close(r, l)	heap_close(r, l)
-#endif
-
-#include "access/heapam.h"
-
-#ifndef OBJECTADDRESS
-#include "utils/tqual.h"
-#endif
-
-#ifndef Anum_pg_proc_oid
-#include "access/sysattr.h"
-#define Anum_pg_proc_oid ObjectIdAttributeNumber
-#define Anum_pg_authid_oid ObjectIdAttributeNumber
-#endif
 
 /*
  * _scan_key_init
@@ -228,14 +156,19 @@ _scan_key_init(ScanKey entry,
         }
 }
 
+// Introduces two-argument GetUserNameFromId
+#define GETUSERNAMEFROMID(ouserid) GetUserNameFromId(ouserid, false)
+
 #ifndef INITSESSIONUSER
-#define _InitializeSessionUserId(name,ouserid) InitializeSessionUserId(name)
+#define INITSESSIONUSER
+#define _InitializeSessionUserId(name,ouserid) InitializeSessionUserId(name,ouserid)
+
 #endif
 
-#endif /* 9.4 */
+#endif /* 12+ */
 
-#if !defined(PG_VERSION_NUM) || PG_VERSION_NUM < 90400
-#error "This extension only builds with PostgreSQL 9.4 or later"
+#if !defined(PG_VERSION_NUM) || PG_VERSION_NUM < 120000
+#error "This extension only builds with PostgreSQL 12 or later"
 #endif
 
 /* Use our version-specific static declaration here */


### PR DESCRIPTION
These versions are EOL so it make sense to remove them.